### PR TITLE
_data/events.yml: add matsue06.

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -252,6 +252,11 @@
   title: TokyuRuby会議08
   start_on: 2014-11-29
   end_on: 2014-11-29
+- name: matsue06
+  title: "松江Ruby会議05"
+  start_on: 2014-12-20
+  end_on: 2014-12-20
+  external_url: http://matsue.rubyist.net/matrk06/
 - name: kana01
   title: "神奈川Ruby会議01"
   start_on: '2015-01-17'


### PR DESCRIPTION
[松江Ruby会議06](http://matsue.rubyist.net/matrk06/)の情報がなかったので追加しました。問題なければ取り込みよろしくお願いします。
