### PR TITLE
Add matrk07

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -279,3 +279,8 @@
   title: "TokyuRuby会議09"
   start_on: 2015-08-29
   end_on: 2015-08-29
+- name: matsue07
+  title: "松江Ruby会議07"
+  start_on: 2015-09-26
+  end_on: 2015-09-26
+  external_url: http://matsue.rubyist.net/matrk07/


### PR DESCRIPTION
度々ですみません。[松江Ruby会議07](http://matsue.rubyist.net/matrk07/)の公式サイトを公開したので追加しました。matsue07/index.htmlについては過去(RegionalRubyKaigi:1174)のやりとりを参考にnginx.confの編集ではなくリダイレクトする形にしております。

問題なければ取り込みよろしくお願いします。
