### PR TITLE
add Matsue Ruby Kaigi 07 report page.

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -289,6 +289,7 @@
   start_on: 2015-09-26
   end_on: 2015-09-26
   external_url: http://matsue.rubyist.net/matrk07/
+  report_url: http://magazine.rubyist.net/?0052-MatsueRubyKaigi07Report
 - name: oedo05
   title: "大江戸Ruby会議05"
   start_on: 2015-11-08


### PR DESCRIPTION
松江Ruby会議07のレポートページを追記しました。
