### PR TITLE
Add Kansai RubyKaigi 2017 to event

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -323,3 +323,7 @@
   title: "大江戸Ruby会議06"
   start_on: 2017-03-20
   end_on: 2017-03-20
+- name: kansai2017
+  title: "関西Ruby会議2017"
+  start_on: 2017-05-27
+  end_on: 2017-05-27


### PR DESCRIPTION
`関西Ruby会議2017`をイベントに追加しました。