### PR TITLE
Add report url to Kawasaki Ruby Kaigi 01

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -310,6 +310,7 @@
   title: "川崎Ruby会議01"
   start_on: 2016-08-20
   end_on: 2016-08-20
+  report_url: http://magazine.rubyist.net/?0055-KawasakiRubyKaigi01Report
 - name: matsue08
   title: "松江Ruby会議08"
   start_on: 2016-12-17


### PR DESCRIPTION
川崎Ruby会議01のレポートURLを追記しました。
遅くなってすみません。