### PR TITLE
Add report_urls.

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -316,10 +316,12 @@
   start_on: 2016-12-17
   end_on: 2016-12-17
   external_url: http://matsue.rubyist.net/matrk08/
+  report_url: http://magazine.rubyist.net/?0056-MatsueRubyKaigi08Report
 - name: nagoya03
   title: "名古屋Ruby会議03"
   start_on: 2017-02-11
   end_on: 2017-02-11
+  report_url: http://magazine.rubyist.net/?0056-NagoyaRubyKaigi03Report
 - name: oedo06
   title: "大江戸Ruby会議06"
   start_on: 2017-03-20
@@ -328,6 +330,7 @@
   title: "関西Ruby会議2017"
   start_on: 2017-05-27
   end_on: 2017-05-27
+  report_url: http://magazine.rubyist.net/?0056-KansaiRubyKaigi2017Report
 - name: tokyu11
   title: "TokyuRuby会議11"
   start_on: 2017-07-29


### PR DESCRIPTION
るびま0056号リリースに伴い、地域Ruby会議のレポートが3本（松江Ruby会議08、名古屋Ruby会議03、関西Ruby会議2017）追加されましたので、更新します。
ご確認、よろしくお願いします。