### PR TITLE
Add tokyu12

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -357,3 +357,7 @@
   start_on: 2018-03-10
   end_on: 2018-03-10
   external_url: http://ruby.okinawa/okrk02/
+- name: tokyu12
+  title: "TokyuRuby会議12"
+  start_on: 2018-07-29
+  end_on: 2018-07-29


### PR DESCRIPTION
TokyuRuby会議12の情報を追加しました。

https://tokyurubykaigi.github.io/tokyu12/

こちらのマージ前に転送設定( https://github.com/ruby-no-kai/rko-router/pull/41 )の方もマージお願いします。