### PR TITLE
Add tama01

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -391,3 +391,8 @@
   title: "TokyuRuby会議13"
   start_on: 2019-06-29
   end_on: 2019-06-29
+- name: tama01
+  title: "TamaRuby会議01"
+  start_on: 2019-07-06
+  end_on: 2019-07-06
+  external_url: https://tama-rb.github.io/tamarubykaigi01/


### PR DESCRIPTION
r.rkoにリストされてなかったのでTama Ruby会議01を追加します。

ひとまずトップページからリンクがあるといいかな、と思ったのでリンク先はas-isです。
[ruby-no-kai/rko-router](https://github.com/ruby-no-kai/rko-router)  へのPRはつくってません。

