### PR TITLE
鹿児島Ruby会議01追加

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -409,3 +409,7 @@
   start_on: 2019-11-03
   end_on: 2019-11-03
   external_url: https://toyamarb.github.io/toyama-rubykaigi01/
+- name: kagoshima01
+  title: "鹿児島Ruby会議01"
+  start_on: 2019-11-30
+  end_on: 2019-11-30


### PR DESCRIPTION
鹿児島Ruby会議01を追加します。
https://github.com/ruby-no-kai/official/issues/374