### PR TITLE
鹿児島Ruby会議01にexternal_urlを設定した

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -413,3 +413,4 @@
   title: "鹿児島Ruby会議01"
   start_on: 2019-11-30
   end_on: 2019-11-30
+  external_url: https://k-ruby.github.io/kagoshima-rubykaigi01/


### PR DESCRIPTION
鹿児島Ruby会議01のイベントページが出来つつあるので、external_urlを設定しました！
https://k-ruby.github.io/kagoshima-rubykaigi01/