### PR TITLE
add Osaka02, Toyama01, Kagoshima01 and Heisei01 RubyKaigi Report

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -404,21 +404,25 @@
   title: "大阪Ruby会議02"
   start_on: 2019-09-15
   end_on: 2019-09-15
+  report_url: https://magazine.rubyist.net/articles/0061/0061-OsakaRubyKaigi02Report.html
 - name: toyama01
   title: "富山Ruby会議01"
   start_on: 2019-11-03
   end_on: 2019-11-03
   external_url: https://toyamarb.github.io/toyama-rubykaigi01/
+  report_url: https://magazine.rubyist.net/articles/0061/0061-ToyamaRubyKaigi01Report.html
 - name: kagoshima01
   title: "鹿児島Ruby会議01"
   start_on: 2019-11-30
   end_on: 2019-11-30
   external_url: https://k-ruby.github.io/kagoshima-rubykaigi01/
+  report_url: https://magazine.rubyist.net/articles/0061/0061-KagoshimaRubyKaigi01Report.html
 - name: heisei01
   title: "平成Ruby会議01"
   start_on: 2019-12-14
   end_on: 2019-12-14
   external_url: https://heiseirb.github.io/kaigi01/
+  report_url: https://magazine.rubyist.net/articles/0061/0061-HeiseiRubyKaigi01Report.html
 - name: oedo08
   title: "大江戸Ruby会議08"
   start_on: 2020-02-11


### PR DESCRIPTION
るびま0061号リリースに伴い大阪02、富山01、鹿児島01、平成01Ruby会議のreport_urlを追記しました。