### PR TITLE
使わなくなったoedo02を削除

### DIFF
--- a/oedo02/index.html
+++ b/oedo02/index.html
@@ -1,1 +1,0 @@
-<html><head><meta http-equiv="refresh" content="0; url=https://magazine.rubyist.net/articles/0039/0039-MetPragdaveAtAsakusarb.html" /></head><body><p>Redirecting to <a href="https://magazine.rubyist.net/articles/0039/0039-MetPragdaveAtAsakusarb.html">https://magazine.rubyist.net/articles/0039/0039-MetPragdaveAtAsakusarb.html</a></body></html>


### PR DESCRIPTION
https://github.com/ruby-no-kai/rko-router/pull/65 以降、oedo02へのリクエストはrko-router上で処理されるようになったので、こちらのHTMLは不要になりました。