### PR TITLE
鹿児島Ruby会議02の情報を追加

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -446,3 +446,7 @@
   title: "福岡Rubyist会議03"
   start_on: 2023-02-18
   end_on: 2023-02-18
+- name: kagoshima02
+  title: "鹿児島Ruby会議02"
+  start_on: 2023-03-04
+  end_on: 2023-03-04


### PR DESCRIPTION
地域Ruby会議(Regional RubyKaigi)のページに鹿児島Ruby会議02の情報を追加します。
https://github.com/ruby-no-kai/official/issues/451