### PR TITLE
Fix external URL for 大阪Ruby会議04

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -472,7 +472,7 @@
   title: "大阪Ruby会議04"
   start_on: 2024-08-24
   end_on: 2024-08-24
-  external_url: https://rubykansai.github.io/osaka03/
+  external_url: https://rubykansai.github.io/osaka04/
 - name: fukuoka04
   title: "福岡Rubyist会議04"
   start_on: 2024-09-07


### PR DESCRIPTION
`external_url`が大阪Ruby会議03のものになっていたので修正いたしました。