### PR TITLE
Update link to point RubyEventCheck

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@ layout: default
 
 <h2>地域Ruby会議</h2>
 
-<p>未確定情報を含む、今後の開催情報は、日本Ruby会の公式Wikiの<a href="https://github.com/ruby-no-kai/official/wiki/Upcomingregionalrubykaigi">これから開催される地域Ruby会議</a>のページも参照してください。</p>
+<p>未確定情報を含む、今後の開催情報は、日本Ruby会の公式Wikiの<a href="https://scrapbox.io/ruby-no-kai/RubyEventCheck">RubyEventCheck</a>のページも参照してください。</p>
 
 <table>
 <th>


### PR DESCRIPTION
The GitHub Wiki page seems to be deprecated, so I updated the link.