### PR TITLE
Add link to tokyo12

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -487,3 +487,8 @@
   start_on: 2024-10-05
   end_on: 2024-10-05
   external_url: http://matsue.rubyist.net/matrk11/
+- name: tokyo12
+  title: "東京Ruby会議12"
+  start_on: 2025-01-18
+  end_on: 2025-01-18
+  external_url: https://regional.rubykaigi.org/tokyo12/


### PR DESCRIPTION
[東京Ruby会議12](https://regional.rubykaigi.org/tokyo12/) へのリンクを追加します。