### PR TITLE
大江戸Ruby会議02のリンク切れを修正

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -143,8 +143,8 @@
   title: "大江戸Ruby会議02"
   start_on: 2012-02-21
   end_on: 2012-02-21
-  external_url: http://jp.rubyist.net/magazine/?0039-MetPragdaveAtAsakusarb
-  report_url: http://jp.rubyist.net/magazine/?0039-MetPragdaveAtAsakusarb
+  external_url: 'https://magazine.rubyist.net/articles/0039/0039-MetPragdaveAtAsakusarb.html#:~:text=%E3%81%97%E3%81%A6%E3%81%84%E3%81%BE%E3%81%99%E3%80%82-,%E5%A4%A7%E6%B1%9F%E6%88%B8%20Ruby%20%E4%BC%9A%E8%AD%B0%2002,-%E3%81%95%E3%81%A6%E3%80%81%E3%81%82%E3%81%BE%E3%82%8A%E3%81%AB%20Dave'
+  report_url: https://magazine.rubyist.net/articles/0039/0039-MetPragdaveAtAsakusarb.html
 - name: minato01
   title: "みなとRuby会議01"
   start_on: 2012-06-02


### PR DESCRIPTION
`http://jp.rubyist.net/magazine/?0039-MetPragdaveAtAsakusarb`はリンク切れになっているので <https://magazine.rubyist.net/articles/0039/0039-MetPragdaveAtAsakusarb.html> に修正しました

 * リンク先が同じだとミスのように見えてしまうので、意図がわかる箇所への[テキストフラグメント](https://developer.mozilla.org/ja/docs/Web/URI/Reference/Fragment/Text_fragments)リンクにしています
   * <a href="https://magazine.rubyist.net/articles/0039/0039-MetPragdaveAtAsakusarb.html#:~:text=%E3%81%97%E3%81%A6%E3%81%84%E3%81%BE%E3%81%99%E3%80%82-,%E5%A4%A7%E6%B1%9F%E6%88%B8%20Ruby%20%E4%BC%9A%E8%AD%B0%2002,-%E3%81%95%E3%81%A6%E3%80%81%E3%81%82%E3%81%BE%E3%82%8A%E3%81%AB%20Dave"><img width="1192" height="266" alt="" src="https://github.com/user-attachments/assets/db9beed8-6869-4c19-a970-648d10b25001" /></a>
 * 周辺の経緯を含めると[Regional RubyKaigi/東京の地域Ruby会議開催カウントの歴史 - ruby-no-kai](https://scrapbox.io/ruby-no-kai/Regional_RubyKaigi%2F%E6%9D%B1%E4%BA%AC%E3%81%AE%E5%9C%B0%E5%9F%9FRuby%E4%BC%9A%E8%AD%B0%E9%96%8B%E5%82%AC%E3%82%AB%E3%82%A6%E3%83%B3%E3%83%88%E3%81%AE%E6%AD%B4%E5%8F%B2)の方が詳細に説明されていますが、大江戸Ruby会議が主題ではないのでRubyist Magazineの記事のみにしています
