### PR TITLE
Add tokyo13

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -533,6 +533,11 @@
   title: "松江Ruby会議12"
   start_on: 2026-06-06
   end_on: 2026-06-06
+- name: tokyo13
+  title: "東京Ruby会議13"
+  start_on: 2026-06-27
+  end_on: 2026-06-27
+  external_url: https://regional.rubykaigi.org/tokyo13/
 - name: kansai09
   title: "関西Ruby会議09"
   start_on: 2026-07-18

--- a/tokyo13/index.html
+++ b/tokyo13/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>東京Ruby会議13</title>
+  
+  <meta property="og:title" content="東京Ruby会議13">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://regional.rubykaigi.org/tokyo13/">
+  <meta property="og:site_name" content="東京Ruby会議13">
+  
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="東京Ruby会議13">
+</head>
+<body>
+  <h1>東京Ruby会議13</h1>
+  
+  <dl>
+    <dt>開催日</dt>
+    <dd>2026年6月27日(土)</dd>
+    
+    <dt>会場</dt>
+    <dd>
+      <a href="https://za-koenji.jp/" target="_blank" rel="noopener noreferrer">座・高円寺2</a><br>
+      JR中央線　高円寺駅　北口より徒歩5分
+    </dd>
+  </dl>
+</body>
+</html>


### PR DESCRIPTION
https://github.com/ruby-no-kai/official/issues/546  で開催について話されている東京Ruby会議13の情報を追加します。イベントページをどう追加するかはまだ検討しているところなので、一旦素朴なHTMLを追加することにします。