### PR TITLE
Update the date of izumo01

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -522,8 +522,8 @@
   external_url: https://regional.rubykaigi.org/hokuriku01/
 - name: izumo01
   title: "出雲Ruby会議01"
-  start_on: 2026-02-22
-  end_on: 2026-02-22
+  start_on: 2026-02-21
+  end_on: 2026-02-21
 - name: fukuoka05
   title: "福岡Rubyist会議05"
   start_on: 2026-02-28


### PR DESCRIPTION
https://github.com/ruby-no-kai/official/issues/540#issuecomment-3658415134 にて、出雲Ruby会議01の正式な開催日が2/21となることがアナウンスされています。
(公式サイトも公開済み https://regional.rubykaigi.org/izumo01/ )
これに合わせてregional.rubykaigi.orgの方の掲載情報も開催日を2/22→2/21へ更新したいです。