### PR TITLE
Add external_url for 松江Ruby会議12

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -537,6 +537,7 @@
   title: "松江Ruby会議12"
   start_on: 2026-06-06
   end_on: 2026-06-06
+  external_url: https://matsue.rubyist.net/matrk12/
 - name: tokyo13
   title: "東京Ruby会議13"
   start_on: 2026-06-27


### PR DESCRIPTION
松江Ruby会議12のURLは `https://regional.rubykaigi.org/matsue12` ではなく `https://matsue.rubyist.net/matrk12/` なので修正します。