### PR TITLE
s/関ヶ原/関ケ原/

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -530,9 +530,10 @@
   end_on: 2026-02-28
   external_url: https://regional.rubykaigi.org/fukuoka05/
 - name: sekigahara01
-  title: "関ヶ原Ruby会議01"
+  title: "関ケ原Ruby会議01"
   start_on: 2026-05-30
   end_on: 2026-05-30
+  external_url: https://regional.rubykaigi.org/sekigahara01/
 - name: matsue12
   title: "松江Ruby会議12"
   start_on: 2026-06-06


### PR DESCRIPTION
自治体の名称「関ケ原町」にあわせて、「関ヶ原」ではなく「関ケ原」の表記としています。
https://www.town.sekigahara.gifu.jp/